### PR TITLE
Add support for gulpfile.babel.js and test

### DIFF
--- a/loaders.js
+++ b/loaders.js
@@ -84,6 +84,7 @@ class gulpLoader extends taskLoader {
 
 	handleFunc(file, callback) {
 		let relativePath = path.relative(vscode.workspace.rootPath, path.dirname(file.fileName));
+		if (relativePath === "") relativePath = null;
 
 		child_process.exec('gulp --tasks-simple', {
 			cwd: vscode.workspace.rootPath,

--- a/loaders.js
+++ b/loaders.js
@@ -90,7 +90,7 @@ class gulpLoader extends taskLoader {
 			timeout: 10000
 		}, (err, stdout, stderr) => {
 			if (err) {
-				console.log(stderr);
+				console.error(stderr);
 				return this.oldRegexHandler(file, callback);
 			}
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "quicktask.gulpGlob": {
           "type": "array",
           "default": [
+            "gulpfile.babel.js",
             "gulpfile.js"
           ],
           "description": "The glob which Quick Task will scan for gulp tasks."

--- a/package.json
+++ b/package.json
@@ -48,25 +48,18 @@
           "description": "Search task from subdirectories for npm and gulp etc. (experimental)"
         },
         "quicktask.excludesGlob": {
-          "type": "array",
-          "default": [
-            "**/{node_modules,.vscode-test,.git}"
-          ],
+          "type": "string",
+          "default": "**/{node_modules,.vscode-test,.git}",
           "description": "The glob which Quick Task will exclude from scans."
         },
         "quicktask.gulpGlob": {
-          "type": "array",
-          "default": [
-            "gulpfile.babel.js",
-            "gulpfile.js"
-          ],
+          "type": "string",
+          "default": "gulpfile{,.babel}.js",
           "description": "The glob which Quick Task will scan for gulp tasks."
         },
         "quicktask.npmGlob": {
-          "type": "array",
-          "default": [
-            "package.json"
-          ],
+          "type": "string",
+          "default": "package.json",
           "description": "The glob which Quick Task will scan for npm tasks."
         },
         "quicktask.defaultTasks": {

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,0 +1,1 @@
+{"plugins": ["transform-es2015-modules-commonjs"]}

--- a/test/gulpfile.babel.js
+++ b/test/gulpfile.babel.js
@@ -1,0 +1,6 @@
+import gulp from 'gulp'
+
+export function babel() {}
+export function watch() {}
+export const copy = () => gulp.parallel(watch, function() {})
+export default () => gulp.parallel(babel, watch)

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -1,11 +1,6 @@
 let gulp = require('gulp');
 
-gulp.task('watch', function () {
-	return;
-});
-
+gulp.task('coffee', function () {});
+gulp.task('watch', function () {});
 gulp.task('default', ['coffee', 'watch']);
-
-gulp.task('copy', ['watch'], function () {
-	return;
-});
+gulp.task('copy', ['watch'], function () {});


### PR DESCRIPTION
there’s a problem: to test `gulpfile.js`, you need gulp v3 installed, to test `gulpfile.babel.js`, you need gulp v4 installed.

seem like your tests aren’t working at all.

PS: if you want to test gulpfile.babel.js, you also need `babel-register` and `babel-plugin-transform-es2015-modules-commonjs`