### PR TITLE
Fixed comment stripping regex to allow urls

### DIFF
--- a/out/src/loaders.js
+++ b/out/src/loaders.js
@@ -52,7 +52,7 @@ class VSLoader extends TaskLoader {
     }
     handleFunc(file, callback) {
         try {
-            const pattern = JSON.parse(file.getText().replace(new RegExp("//.*", "gi"), ""));
+            const pattern = JSON.parse(file.getText().replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, '$1'));
             if (Array.isArray(pattern.tasks)) {
                 for (const task of pattern.tasks) {
                     const cmdLine = "label" in task ? task.label : task.taskName;


### PR DESCRIPTION
Regular expression used to remove comments from tasks.json updated to prevent URLs in commands and arguments being stripped. Used a [StackOverflow post](https://stackoverflow.com/questions/5989315/regex-for-match-replacing-javascript-comments-both-multiline-and-inline#15123777) as a reference to the best way to avoid matching double-slash in URLs.

Addresses issue #22 